### PR TITLE
make accountOfficialName and balanceAvailable optional

### DIFF
--- a/Data/Api/Types.hs
+++ b/Data/Api/Types.hs
@@ -304,7 +304,7 @@ $(deriveJSON (defaultOptions { fieldLabelModifier = quietSnake . drop 12 }) ''Cu
 
 data Balance =
   Balance
-    { balanceAvailable              :: Double
+    { balanceAvailable              :: Maybe Double
     , balanceCurrent                :: Double
     , balanceLimit                  :: Maybe Double
     , balanceIsoCurrencyCode        :: CurrencyCode
@@ -319,7 +319,7 @@ data Account =
     , accountBalances     :: Balance
     , accountMask         :: Text
     , accountName         :: Text
-    , accountOfficialName :: Text
+    , accountOfficialName :: Maybe Text
     , accountSubtype      :: Text
     , accountType         :: Text
     } deriving (Eq, Show)


### PR DESCRIPTION
some banks do not use the accountOfficialName field. some brokerage accounts do not use the balanceAvailable field